### PR TITLE
Update ski resort data parse workflow, include mountain statistics

### DIFF
--- a/notebooks/NY_SKI_ROUTING.ipynb
+++ b/notebooks/NY_SKI_ROUTING.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import Libraries"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -23,6 +30,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Sourcing\n",
+    "For the purpose of optimizing routes for ski resorts and areas in New York state. The names of these areas are to be parsed from the following website.\n",
+    "\n",
+    "[Ski Central]('https://www.skicentral.com/') - A popular site to review popular ski destinations worldwide.\n",
+    "\n",
+    "For the purposes of this optimization, we have restricted the area selection to New York state. The state with the most ski resorts and areas in the US. Obtaining these names and their location data is a straight forward procedure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Web Scraping (Resort Names)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
@@ -31,24 +57,58 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "[<div class=\"resorttitle\"><a href=\"whiteface.html\">Whiteface Mountain</a></div>, <div class=\"resorttitle\"><a href=\"goremountain.html\">Gore Mountain</a></div>, <div class=\"resorttitle\"><a href=\"huntermountain.html\">Hunter Mountain</a></div>, <div class=\"resorttitle\"><a href=\"belleayre.html\">Belleayre Mountain</a></div>, <div class=\"resorttitle\"><a href=\"holidayvalley.html\">Holiday Valley</a></div>, <div class=\"resorttitle\"><a href=\"skiwindham.html\">Windham Mountain</a></div>, <div class=\"resorttitle\"><a href=\"greekpeak.html\">Greek Peak</a></div>, <div class=\"resorttitle\"><a href=\"catamount.html\">Catamount Ski Area</a></div>, <div class=\"resorttitle\"><a href=\"peeknpeak.html\">Peek'n Peak Resort</a></div>, <div class=\"resorttitle\"><a href=\"holimont.html\">HoliMont</a></div>, <div class=\"resorttitle\"><a href=\"beartownskiarea.html\">Beartown Ski Area</a></div>, <div class=\"resorttitle\"><a href=\"brantlingskiandsnowboardcenter.html\">Brantling Ski and Snowboard Center</a></div>, <div class=\"resorttitle\"><a href=\"bristolmountain.html\">Bristol Mountain</a></div>, <div class=\"resorttitle\"><a href=\"buffaloskiclub.html\">Buffalo Ski Club</a></div>, <div class=\"resorttitle\"><a href=\"cazenoviaskiclub.html\">Cazenovia Ski Club</a></div>, <div class=\"resorttitle\"><a href=\"cockaigneskiarea.html\">Cockaigne Ski Area</a></div>, <div class=\"resorttitle\"><a href=\"dryhill.html\">Dry Hill Ski Area</a></div>, <div class=\"resorttitle\"><a href=\"fourseasonsgolfandskicenter.html\">Four Seasons Golf and Ski Center</a></div>, <div class=\"resorttitle\"><a href=\"hickoryskicenter.html\">Hickory Ski Center</a></div>, <div class=\"resorttitle\"><a href=\"holidaymountain.html\">Holiday Mountain</a></div>, <div class=\"resorttitle\"><a href=\"hunthollowskiclub.html\">Hunt Hollow Ski Club</a></div>, <div class=\"resorttitle\"><a href=\"kissingbridge.html\">Kissing Bridge</a></div>, <div class=\"resorttitle\"><a href=\"labradormountain.html\">Labrador Mountain</a></div>, <div class=\"resorttitle\"><a href=\"mapleskiridge.html\">Maple Ski Ridge</a></div>, <div class=\"resorttitle\"><a href=\"mccauleymountain.html\">McCauley Mountain</a></div>, <div class=\"resorttitle\"><a href=\"mountpisgah.html\">Mount Pisgah</a></div>, <div class=\"resorttitle\"><a href=\"mtpeterskiarea.html\">Mt. Peter Ski Area</a></div>, <div class=\"resorttitle\"><a href=\"oakmountainskicenter.html\">Oak Mountain Ski Center</a></div>, <div class=\"resorttitle\"><a href=\"plattekill.html\">Plattekill</a></div>, <div class=\"resorttitle\"><a href=\"polarpeakskibowl.html\">Polar Peak Ski Bowl</a></div>, <div class=\"resorttitle\"><a href=\"royalmountainskiarea.html\">Royal Mountain Ski Area</a></div>, <div class=\"resorttitle\"><a href=\"bigtupper.html\">Ski Big Tupper Again</a></div>, <div class=\"resorttitle\"><a href=\"skiventure.html\">Ski Venture</a></div>, <div class=\"resorttitle\"><a href=\"snowridgeskiarea.html\">Snow Ridge Ski Area</a></div>, <div class=\"resorttitle\"><a href=\"songmountain.html\">Song Mountain</a></div>, <div class=\"resorttitle\"><a href=\"swainskicenter.html\">Swain Resort</a></div>, <div class=\"resorttitle\"><a href=\"thunderridgeskiarea.html\">Thunder Ridge Ski Area</a></div>, <div class=\"resorttitle\"><a href=\"titus.html\">Titus Mountain</a></div>, <div class=\"resorttitle\"><a href=\"westmountainskicenter.html\">West Mountain Ski Center</a></div>, <div class=\"resorttitle\"><a href=\"willardmountainnewyork.html\">Willard Mountain</a></div>, <div class=\"resorttitle\"><a href=\"woodsvalleyskiarea.html\">Woods Valley Ski Area</a></div>]\n",
       "['Whiteface Mountain', 'Gore Mountain', 'Hunter Mountain', 'Belleayre Mountain', 'Holiday Valley', 'Windham Mountain', 'Greek Peak', 'Catamount Ski Area', \"Peek'n Peak Resort\", 'HoliMont', 'Beartown Ski Area', 'Brantling Ski and Snowboard Center', 'Bristol Mountain', 'Buffalo Ski Club', 'Cazenovia Ski Club', 'Cockaigne Ski Area', 'Dry Hill Ski Area', 'Four Seasons Golf and Ski Center', 'Hickory Ski Center', 'Holiday Mountain', 'Hunt Hollow Ski Club', 'Kissing Bridge', 'Labrador Mountain', 'Maple Ski Ridge', 'McCauley Mountain', 'Mount Pisgah', 'Mt. Peter Ski Area', 'Oak Mountain Ski Center', 'Plattekill', 'Polar Peak Ski Bowl', 'Royal Mountain Ski Area', 'Ski Big Tupper Again', 'Ski Venture', 'Snow Ridge Ski Area', 'Song Mountain', 'Swain Resort', 'Thunder Ridge Ski Area', 'Titus Mountain', 'West Mountain Ski Center', 'Willard Mountain', 'Woods Valley Ski Area']\n"
      ]
     }
    ],
    "source": [
-    "url = \"https://www.skicentral.com/newyork.html\"\n",
-    "response = requests.get(url)\n",
-    "\n",
+    "base_url = \"https://www.skicentral.com\"\n",
+    "response = requests.get(f\"{base_url}/newyork.html\")\n",
     "soup = BeautifulSoup(response.text, 'html.parser')\n",
     "\n",
     "resort_titles = soup.find_all('div', class_='resorttitle')\n",
     "resort_names = [title.text.strip() for title in resort_titles]\n",
+    "print(resort_titles)\n",
     "print(resort_names)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parse and collect resort data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'name': 'Whiteface Mountain', 'url': 'https://www.skicentral.com/whiteface.html'}, {'name': 'Gore Mountain', 'url': 'https://www.skicentral.com/goremountain.html'}, {'name': 'Hunter Mountain', 'url': 'https://www.skicentral.com/huntermountain.html'}, {'name': 'Belleayre Mountain', 'url': 'https://www.skicentral.com/belleayre.html'}, {'name': 'Holiday Valley', 'url': 'https://www.skicentral.com/holidayvalley.html'}, {'name': 'Windham Mountain', 'url': 'https://www.skicentral.com/skiwindham.html'}, {'name': 'Greek Peak', 'url': 'https://www.skicentral.com/greekpeak.html'}, {'name': 'Catamount Ski Area', 'url': 'https://www.skicentral.com/catamount.html'}, {'name': \"Peek'n Peak Resort\", 'url': 'https://www.skicentral.com/peeknpeak.html'}, {'name': 'HoliMont', 'url': 'https://www.skicentral.com/holimont.html'}, {'name': 'Beartown Ski Area', 'url': 'https://www.skicentral.com/beartownskiarea.html'}, {'name': 'Brantling Ski and Snowboard Center', 'url': 'https://www.skicentral.com/brantlingskiandsnowboardcenter.html'}, {'name': 'Bristol Mountain', 'url': 'https://www.skicentral.com/bristolmountain.html'}, {'name': 'Buffalo Ski Club', 'url': 'https://www.skicentral.com/buffaloskiclub.html'}, {'name': 'Cazenovia Ski Club', 'url': 'https://www.skicentral.com/cazenoviaskiclub.html'}, {'name': 'Cockaigne Ski Area', 'url': 'https://www.skicentral.com/cockaigneskiarea.html'}, {'name': 'Dry Hill Ski Area', 'url': 'https://www.skicentral.com/dryhill.html'}, {'name': 'Four Seasons Golf and Ski Center', 'url': 'https://www.skicentral.com/fourseasonsgolfandskicenter.html'}, {'name': 'Hickory Ski Center', 'url': 'https://www.skicentral.com/hickoryskicenter.html'}, {'name': 'Holiday Mountain', 'url': 'https://www.skicentral.com/holidaymountain.html'}, {'name': 'Hunt Hollow Ski Club', 'url': 'https://www.skicentral.com/hunthollowskiclub.html'}, {'name': 'Kissing Bridge', 'url': 'https://www.skicentral.com/kissingbridge.html'}, {'name': 'Labrador Mountain', 'url': 'https://www.skicentral.com/labradormountain.html'}, {'name': 'Maple Ski Ridge', 'url': 'https://www.skicentral.com/mapleskiridge.html'}, {'name': 'McCauley Mountain', 'url': 'https://www.skicentral.com/mccauleymountain.html'}, {'name': 'Mount Pisgah', 'url': 'https://www.skicentral.com/mountpisgah.html'}, {'name': 'Mt. Peter Ski Area', 'url': 'https://www.skicentral.com/mtpeterskiarea.html'}, {'name': 'Oak Mountain Ski Center', 'url': 'https://www.skicentral.com/oakmountainskicenter.html'}, {'name': 'Plattekill', 'url': 'https://www.skicentral.com/plattekill.html'}, {'name': 'Polar Peak Ski Bowl', 'url': 'https://www.skicentral.com/polarpeakskibowl.html'}, {'name': 'Royal Mountain Ski Area', 'url': 'https://www.skicentral.com/royalmountainskiarea.html'}, {'name': 'Ski Big Tupper Again', 'url': 'https://www.skicentral.com/bigtupper.html'}, {'name': 'Ski Venture', 'url': 'https://www.skicentral.com/skiventure.html'}, {'name': 'Snow Ridge Ski Area', 'url': 'https://www.skicentral.com/snowridgeskiarea.html'}, {'name': 'Song Mountain', 'url': 'https://www.skicentral.com/songmountain.html'}, {'name': 'Swain Resort', 'url': 'https://www.skicentral.com/swainskicenter.html'}, {'name': 'Thunder Ridge Ski Area', 'url': 'https://www.skicentral.com/thunderridgeskiarea.html'}, {'name': 'Titus Mountain', 'url': 'https://www.skicentral.com/titus.html'}, {'name': 'West Mountain Ski Center', 'url': 'https://www.skicentral.com/westmountainskicenter.html'}, {'name': 'Willard Mountain', 'url': 'https://www.skicentral.com/willardmountainnewyork.html'}, {'name': 'Woods Valley Ski Area', 'url': 'https://www.skicentral.com/woodsvalleyskiarea.html'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "resorts = []\n",
+    "for title in resort_titles:\n",
+    "    link = title.find('a')\n",
+    "    if link:\n",
+    "        resort_url = base_url + \"/\" + link.get('href')\n",
+    "        resorts.append({\n",
+    "        'name': title.text.strip(),\n",
+    "        'url': resort_url\n",
+    "    })\n",
+    "print(resorts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -73,6 +133,15 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>name</th>\n",
+       "      <th>url</th>\n",
+       "      <th>vertical_rise</th>\n",
+       "      <th>base_elevation</th>\n",
+       "      <th>summit_elevation</th>\n",
+       "      <th>annual_snowfall</th>\n",
+       "      <th>number_of_trails</th>\n",
+       "      <th>skiable_acres</th>\n",
+       "      <th>longest_run</th>\n",
+       "      <th>snowmaking</th>\n",
        "      <th>latitude</th>\n",
        "      <th>longitude</th>\n",
        "      <th>address</th>\n",
@@ -82,6 +151,15 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Whiteface Mountain</td>\n",
+       "      <td>https://www.skicentral.com/whiteface.html</td>\n",
+       "      <td>3430 ft</td>\n",
+       "      <td>1220 ft</td>\n",
+       "      <td>4650 ft</td>\n",
+       "      <td>190 inches</td>\n",
+       "      <td>90</td>\n",
+       "      <td>288</td>\n",
+       "      <td>2.1 miles / 3.4 km</td>\n",
+       "      <td>98%</td>\n",
        "      <td>44.365784</td>\n",
        "      <td>-73.902984</td>\n",
        "      <td>Whiteface Mountain, Essex County, New York, Un...</td>\n",
@@ -89,6 +167,15 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Gore Mountain</td>\n",
+       "      <td>https://www.skicentral.com/goremountain.html</td>\n",
+       "      <td>2537 ft</td>\n",
+       "      <td>998 ft</td>\n",
+       "      <td>3600 ft</td>\n",
+       "      <td>150 inches</td>\n",
+       "      <td>107</td>\n",
+       "      <td>439</td>\n",
+       "      <td>4.4 miles / 7.1 km</td>\n",
+       "      <td>97%</td>\n",
        "      <td>43.672954</td>\n",
        "      <td>-74.048853</td>\n",
        "      <td>Gore Mountain, Town of Johnsburg, Warren Count...</td>\n",
@@ -96,6 +183,15 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Hunter Mountain</td>\n",
+       "      <td>https://www.skicentral.com/huntermountain.html</td>\n",
+       "      <td>1600 ft</td>\n",
+       "      <td>1600 ft</td>\n",
+       "      <td>3200 ft</td>\n",
+       "      <td>125 inches</td>\n",
+       "      <td>58</td>\n",
+       "      <td>240</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>100%</td>\n",
        "      <td>42.177866</td>\n",
        "      <td>-74.230422</td>\n",
        "      <td>Hunter Mountain, Town of Hunter, Greene County...</td>\n",
@@ -103,6 +199,15 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>Belleayre Mountain</td>\n",
+       "      <td>https://www.skicentral.com/belleayre.html</td>\n",
+       "      <td>1404 ft</td>\n",
+       "      <td>2025 ft</td>\n",
+       "      <td>3429 ft</td>\n",
+       "      <td>141 inches</td>\n",
+       "      <td>50</td>\n",
+       "      <td>171</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>96%</td>\n",
        "      <td>42.126893</td>\n",
        "      <td>-74.474075</td>\n",
        "      <td>Belleayre Mountain Day Use Area, Pine Hill, To...</td>\n",
@@ -110,6 +215,15 @@
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>Holiday Valley</td>\n",
+       "      <td>https://www.skicentral.com/holidayvalley.html</td>\n",
+       "      <td>750 ft</td>\n",
+       "      <td>1500 ft</td>\n",
+       "      <td>2250 ft</td>\n",
+       "      <td>180 inches</td>\n",
+       "      <td>58</td>\n",
+       "      <td>290</td>\n",
+       "      <td>0.8 miles / 1.3 km</td>\n",
+       "      <td>95%</td>\n",
        "      <td>42.263145</td>\n",
        "      <td>-78.663611</td>\n",
        "      <td>Holiday Valley, Town of Ellicottville, Cattara...</td>\n",
@@ -117,6 +231,15 @@
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>Windham Mountain</td>\n",
+       "      <td>https://www.skicentral.com/skiwindham.html</td>\n",
+       "      <td>1600 ft</td>\n",
+       "      <td>1500 ft</td>\n",
+       "      <td>3100 ft</td>\n",
+       "      <td>105 inches</td>\n",
+       "      <td>54</td>\n",
+       "      <td>285</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>97%</td>\n",
        "      <td>42.293926</td>\n",
        "      <td>-74.261312</td>\n",
        "      <td>Windham Mountain Club, Town of Windham, Greene...</td>\n",
@@ -124,160 +247,559 @@
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>Greek Peak</td>\n",
+       "      <td>https://www.skicentral.com/greekpeak.html</td>\n",
+       "      <td>952 ft</td>\n",
+       "      <td>1148 ft</td>\n",
+       "      <td>2100 ft</td>\n",
+       "      <td>122 inches</td>\n",
+       "      <td>38</td>\n",
+       "      <td>220</td>\n",
+       "      <td>1.5 miles / 2.4 km</td>\n",
+       "      <td>83%</td>\n",
        "      <td>42.502320</td>\n",
        "      <td>-76.148046</td>\n",
        "      <td>Greek Peak Mountain Resort, 2000, South Hill R...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
+       "      <td>Catamount Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/catamount.html</td>\n",
+       "      <td>1000 ft</td>\n",
+       "      <td>1000 ft</td>\n",
+       "      <td>2000 ft</td>\n",
+       "      <td>75 inches</td>\n",
+       "      <td>36</td>\n",
+       "      <td>130</td>\n",
+       "      <td>1.8 miles / 2.8 km</td>\n",
+       "      <td>98%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
        "      <td>Peek'n Peak Resort</td>\n",
+       "      <td>https://www.skicentral.com/peeknpeak.html</td>\n",
+       "      <td>400 ft</td>\n",
+       "      <td>1400 ft</td>\n",
+       "      <td>1800 ft</td>\n",
+       "      <td>200 inches</td>\n",
+       "      <td>27</td>\n",
+       "      <td>105</td>\n",
+       "      <td>0 miles / 1 km</td>\n",
+       "      <td>100%</td>\n",
        "      <td>42.060463</td>\n",
        "      <td>-79.744066</td>\n",
        "      <td>Peek'n Peak Resort, Abbey Lane, Town of French...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>8</th>\n",
+       "      <th>9</th>\n",
        "      <td>HoliMont</td>\n",
+       "      <td>https://www.skicentral.com/holimont.html</td>\n",
+       "      <td>700 ft</td>\n",
+       "      <td>1560 ft</td>\n",
+       "      <td>2260 ft</td>\n",
+       "      <td>180 inches</td>\n",
+       "      <td>52</td>\n",
+       "      <td>135</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>100%</td>\n",
        "      <td>42.270015</td>\n",
        "      <td>-78.683382</td>\n",
        "      <td>Holimont, Village of Ellicottville, Town of El...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>9</th>\n",
+       "      <th>10</th>\n",
        "      <td>Beartown Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/beartownskiarea.html</td>\n",
+       "      <td>150 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>9</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>yes</td>\n",
        "      <td>44.764111</td>\n",
        "      <td>-73.584055</td>\n",
        "      <td>Beartown Ski Area, Beartown Road, Beartown, To...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>10</th>\n",
+       "      <th>11</th>\n",
+       "      <td>Brantling Ski and Snowboard Center</td>\n",
+       "      <td>https://www.skicentral.com/brantlingskiandsnow...</td>\n",
+       "      <td>240 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>9</td>\n",
+       "      <td>35</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>60%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
        "      <td>Bristol Mountain</td>\n",
+       "      <td>https://www.skicentral.com/bristolmountain.html</td>\n",
+       "      <td>1200 ft</td>\n",
+       "      <td>1000 ft</td>\n",
+       "      <td>2200 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>35</td>\n",
+       "      <td>138</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>97%</td>\n",
        "      <td>42.744830</td>\n",
        "      <td>-77.403694</td>\n",
        "      <td>Bristol Mountain, North Star Village, Town of ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>11</th>\n",
+       "      <th>13</th>\n",
        "      <td>Buffalo Ski Club</td>\n",
+       "      <td>https://www.skicentral.com/buffaloskiclub.html</td>\n",
+       "      <td>500 ft</td>\n",
+       "      <td>2025 ft</td>\n",
+       "      <td>3429 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>43</td>\n",
+       "      <td>300</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>yes</td>\n",
        "      <td>42.677615</td>\n",
        "      <td>-78.697081</td>\n",
        "      <td>Buffalo Ski Club, Town of Boston, Erie County,...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>12</th>\n",
+       "      <th>14</th>\n",
        "      <td>Cazenovia Ski Club</td>\n",
+       "      <td>https://www.skicentral.com/cazenoviaskiclub.html</td>\n",
+       "      <td>460 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>13</td>\n",
+       "      <td>25</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>no</td>\n",
        "      <td>42.977599</td>\n",
        "      <td>-75.852806</td>\n",
        "      <td>Cazenovia Ski Club, Rathbun Road, Town of Caze...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>13</th>\n",
+       "      <th>15</th>\n",
+       "      <td>Cockaigne Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/cockaigneskiarea.html</td>\n",
+       "      <td>430 ft</td>\n",
+       "      <td>1592 ft</td>\n",
+       "      <td>2022 ft</td>\n",
+       "      <td>175 inches</td>\n",
+       "      <td>15</td>\n",
+       "      <td>100</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>no</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
        "      <td>Dry Hill Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/dryhill.html</td>\n",
+       "      <td>300 ft</td>\n",
+       "      <td>650 ft</td>\n",
+       "      <td>950 ft</td>\n",
+       "      <td>125 inches</td>\n",
+       "      <td>7</td>\n",
+       "      <td>35</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>yes</td>\n",
        "      <td>43.930346</td>\n",
        "      <td>-75.901776</td>\n",
        "      <td>Dry Hill Ski Area, Town of Watertown, Jefferso...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>14</th>\n",
+       "      <th>17</th>\n",
+       "      <td>Four Seasons Golf and Ski Center</td>\n",
+       "      <td>https://www.skicentral.com/fourseasonsgolfands...</td>\n",
+       "      <td>59 ft</td>\n",
+       "      <td>545 ft</td>\n",
+       "      <td>604 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>4</td>\n",
+       "      <td>12</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>50%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
        "      <td>Hickory Ski Center</td>\n",
+       "      <td>https://www.skicentral.com/hickoryskicenter.html</td>\n",
+       "      <td>1200 ft</td>\n",
+       "      <td>700 ft</td>\n",
+       "      <td>1900 ft</td>\n",
+       "      <td>80 inches</td>\n",
+       "      <td>18</td>\n",
+       "      <td>225</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>no</td>\n",
        "      <td>43.474359</td>\n",
        "      <td>-73.816768</td>\n",
        "      <td>Hickory Ski Center, Hickory Hill Road, Town of...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>15</th>\n",
+       "      <th>19</th>\n",
        "      <td>Holiday Mountain</td>\n",
+       "      <td>https://www.skicentral.com/holidaymountain.html</td>\n",
+       "      <td>400 ft</td>\n",
+       "      <td>1150 ft</td>\n",
+       "      <td>1500 ft</td>\n",
+       "      <td>90 inches</td>\n",
+       "      <td>6</td>\n",
+       "      <td>37</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>100%</td>\n",
        "      <td>41.628043</td>\n",
        "      <td>-74.606688</td>\n",
        "      <td>Holiday Mountain Trail, Bridgeville, Rock Hill...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>16</th>\n",
+       "      <th>20</th>\n",
        "      <td>Hunt Hollow Ski Club</td>\n",
+       "      <td>https://www.skicentral.com/hunthollowskiclub.html</td>\n",
+       "      <td>825 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>20</td>\n",
+       "      <td>80</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>yes</td>\n",
        "      <td>42.644112</td>\n",
        "      <td>-77.481358</td>\n",
        "      <td>Hunt Hollow Ski Club, Hunt Hollow, Town of Nap...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>17</th>\n",
+       "      <th>21</th>\n",
        "      <td>Kissing Bridge</td>\n",
+       "      <td>https://www.skicentral.com/kissingbridge.html</td>\n",
+       "      <td>550 ft</td>\n",
+       "      <td>1200 ft</td>\n",
+       "      <td>1750 ft</td>\n",
+       "      <td>182 inches</td>\n",
+       "      <td>38</td>\n",
+       "      <td>700</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>90%</td>\n",
        "      <td>42.599704</td>\n",
        "      <td>-78.657497</td>\n",
        "      <td>Kissing Bridge, Footes, Town of Concord, Erie ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>18</th>\n",
+       "      <th>22</th>\n",
        "      <td>Labrador Mountain</td>\n",
+       "      <td>https://www.skicentral.com/labradormountain.html</td>\n",
+       "      <td>700 ft</td>\n",
+       "      <td>1125 ft</td>\n",
+       "      <td>1825 ft</td>\n",
+       "      <td>125 inches</td>\n",
+       "      <td>22</td>\n",
+       "      <td>250</td>\n",
+       "      <td>1 miles / 1.6 km</td>\n",
+       "      <td>90%</td>\n",
        "      <td>42.740240</td>\n",
        "      <td>-76.034633</td>\n",
        "      <td>Labrador Mountain, 6935, Town of Truxton, Cort...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>19</th>\n",
+       "      <th>23</th>\n",
        "      <td>Maple Ski Ridge</td>\n",
+       "      <td>https://www.skicentral.com/mapleskiridge.html</td>\n",
+       "      <td>1200 ft</td>\n",
+       "      <td>750 ft</td>\n",
+       "      <td>450 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>8</td>\n",
+       "      <td>25</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>95%</td>\n",
        "      <td>42.815589</td>\n",
        "      <td>-74.031286</td>\n",
        "      <td>Maple Ski Ridge, Mariaville Road, Town of Rott...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20</th>\n",
+       "      <th>24</th>\n",
        "      <td>McCauley Mountain</td>\n",
+       "      <td>https://www.skicentral.com/mccauleymountain.html</td>\n",
+       "      <td>633 ft</td>\n",
+       "      <td>1567 ft</td>\n",
+       "      <td>2200 ft</td>\n",
+       "      <td>281 inches</td>\n",
+       "      <td>21</td>\n",
+       "      <td>75</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>65%</td>\n",
        "      <td>43.395902</td>\n",
        "      <td>-74.889602</td>\n",
        "      <td>McCauley Mountain, Herkimer County, New York, ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>21</th>\n",
+       "      <th>25</th>\n",
        "      <td>Mount Pisgah</td>\n",
+       "      <td>https://www.skicentral.com/mountpisgah.html</td>\n",
+       "      <td>329 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>5</td>\n",
+       "      <td>15</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>100%</td>\n",
        "      <td>44.340885</td>\n",
        "      <td>-74.127932</td>\n",
        "      <td>Mount Pisgah, Town of Saint Armand, Essex Coun...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>22</th>\n",
+       "      <th>26</th>\n",
+       "      <td>Mt. Peter Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/mtpeterskiarea.html</td>\n",
+       "      <td>400 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>49 inches</td>\n",
+       "      <td>14</td>\n",
+       "      <td>69</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>100%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>Oak Mountain Ski Center</td>\n",
+       "      <td>https://www.skicentral.com/oakmountainskicente...</td>\n",
+       "      <td>650 ft</td>\n",
+       "      <td>1750 ft</td>\n",
+       "      <td>2400 ft</td>\n",
+       "      <td>120 inches</td>\n",
+       "      <td>22</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>1.5 miles / 2.4 km</td>\n",
+       "      <td>30%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28</th>\n",
        "      <td>Plattekill</td>\n",
+       "      <td>https://www.skicentral.com/plattekill.html</td>\n",
+       "      <td>1100 ft</td>\n",
+       "      <td>2400 ft</td>\n",
+       "      <td>3500 ft</td>\n",
+       "      <td>190 inches</td>\n",
+       "      <td>35</td>\n",
+       "      <td>112</td>\n",
+       "      <td>2 miles / 3.2 km</td>\n",
+       "      <td>75%</td>\n",
        "      <td>41.618364</td>\n",
        "      <td>-74.063097</td>\n",
        "      <td>Plattekill, Ulster County, New York, 12568, Un...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>23</th>\n",
+       "      <th>29</th>\n",
+       "      <td>Polar Peak Ski Bowl</td>\n",
+       "      <td>https://www.skicentral.com/polarpeakskibowl.html</td>\n",
+       "      <td>114 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>660 ft</td>\n",
+       "      <td>65 inches</td>\n",
+       "      <td>10</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>0.3 miles / 0.4 km</td>\n",
+       "      <td>90%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>30</th>\n",
        "      <td>Royal Mountain Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/royalmountainskiare...</td>\n",
+       "      <td>550 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>14</td>\n",
+       "      <td>30</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>95%</td>\n",
        "      <td>43.083509</td>\n",
        "      <td>-74.506211</td>\n",
        "      <td>Royal Mountain Ski Area, North Bush, Town of C...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24</th>\n",
+       "      <th>31</th>\n",
+       "      <td>Ski Big Tupper Again</td>\n",
+       "      <td>https://www.skicentral.com/bigtupper.html</td>\n",
+       "      <td>1151 ft</td>\n",
+       "      <td>2000 ft</td>\n",
+       "      <td>3136 ft</td>\n",
+       "      <td>90 inches</td>\n",
+       "      <td>25</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>no</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32</th>\n",
+       "      <td>Ski Venture</td>\n",
+       "      <td>https://www.skicentral.com/skiventure.html</td>\n",
+       "      <td>100 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>12</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>no</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>Snow Ridge Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/snowridgeskiarea.html</td>\n",
+       "      <td>500 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>2000 ft</td>\n",
+       "      <td>230 inches</td>\n",
+       "      <td>22</td>\n",
+       "      <td>130</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>50%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>34</th>\n",
+       "      <td>Song Mountain</td>\n",
+       "      <td>https://www.skicentral.com/songmountain.html</td>\n",
+       "      <td>700 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>24</td>\n",
+       "      <td>100</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>80%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
        "      <td>Swain Resort</td>\n",
+       "      <td>https://www.skicentral.com/swainskicenter.html</td>\n",
+       "      <td>650 ft</td>\n",
+       "      <td>1320 ft</td>\n",
+       "      <td>1970 ft</td>\n",
+       "      <td>130 inches</td>\n",
+       "      <td>30</td>\n",
+       "      <td>100</td>\n",
+       "      <td>1 miles / 1.6 km</td>\n",
+       "      <td>97%</td>\n",
        "      <td>42.476051</td>\n",
        "      <td>-77.855432</td>\n",
        "      <td>Swain Resort, County Road 24, Swain, Town of G...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>25</th>\n",
+       "      <th>36</th>\n",
        "      <td>Thunder Ridge Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/thunderridgeskiarea...</td>\n",
+       "      <td>600 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>820 ft</td>\n",
+       "      <td>33 inches</td>\n",
+       "      <td>30</td>\n",
+       "      <td>90</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>100%</td>\n",
        "      <td>41.508554</td>\n",
        "      <td>-73.585486</td>\n",
        "      <td>Thunder Ridge Ski Area, Thunder Ridge Road, To...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>26</th>\n",
+       "      <th>37</th>\n",
        "      <td>Titus Mountain</td>\n",
+       "      <td>https://www.skicentral.com/titus.html</td>\n",
+       "      <td>1200 ft</td>\n",
+       "      <td>825 ft</td>\n",
+       "      <td>2025 ft</td>\n",
+       "      <td>130 inches</td>\n",
+       "      <td>36</td>\n",
+       "      <td>200</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>90%</td>\n",
        "      <td>44.754265</td>\n",
        "      <td>-74.241311</td>\n",
        "      <td>Titus Mountain ski resort, Town of Malone, Fra...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>27</th>\n",
+       "      <th>38</th>\n",
+       "      <td>West Mountain Ski Center</td>\n",
+       "      <td>https://www.skicentral.com/westmountainskicent...</td>\n",
+       "      <td>460 ft</td>\n",
+       "      <td>1010 ft</td>\n",
+       "      <td>1470 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>40</td>\n",
+       "      <td>124</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>70%</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39</th>\n",
        "      <td>Willard Mountain</td>\n",
+       "      <td>https://www.skicentral.com/willardmountainnewy...</td>\n",
+       "      <td>505 ft</td>\n",
+       "      <td>910 ft</td>\n",
+       "      <td>1415 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>14</td>\n",
+       "      <td>50</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>yes</td>\n",
        "      <td>43.019722</td>\n",
        "      <td>-73.522242</td>\n",
        "      <td>Willard Mountain, Washington County, New York,...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>28</th>\n",
+       "      <th>40</th>\n",
        "      <td>Woods Valley Ski Area</td>\n",
+       "      <td>https://www.skicentral.com/woodsvalleyskiarea....</td>\n",
+       "      <td>500 ft</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>15</td>\n",
+       "      <td>25</td>\n",
+       "      <td>n/a</td>\n",
+       "      <td>yes</td>\n",
        "      <td>43.302038</td>\n",
        "      <td>-75.382495</td>\n",
        "      <td>Woods Valley Ski Area, 9100, State Highway 46,...</td>\n",
@@ -287,36 +809,177 @@
        "</div>"
       ],
       "text/plain": [
-       "                       name   latitude  longitude  \\\n",
-       "0        Whiteface Mountain  44.365784 -73.902984   \n",
-       "1             Gore Mountain  43.672954 -74.048853   \n",
-       "2           Hunter Mountain  42.177866 -74.230422   \n",
-       "3        Belleayre Mountain  42.126893 -74.474075   \n",
-       "4            Holiday Valley  42.263145 -78.663611   \n",
-       "5          Windham Mountain  42.293926 -74.261312   \n",
-       "6                Greek Peak  42.502320 -76.148046   \n",
-       "7        Peek'n Peak Resort  42.060463 -79.744066   \n",
-       "8                  HoliMont  42.270015 -78.683382   \n",
-       "9         Beartown Ski Area  44.764111 -73.584055   \n",
-       "10         Bristol Mountain  42.744830 -77.403694   \n",
-       "11         Buffalo Ski Club  42.677615 -78.697081   \n",
-       "12       Cazenovia Ski Club  42.977599 -75.852806   \n",
-       "13        Dry Hill Ski Area  43.930346 -75.901776   \n",
-       "14       Hickory Ski Center  43.474359 -73.816768   \n",
-       "15         Holiday Mountain  41.628043 -74.606688   \n",
-       "16     Hunt Hollow Ski Club  42.644112 -77.481358   \n",
-       "17           Kissing Bridge  42.599704 -78.657497   \n",
-       "18        Labrador Mountain  42.740240 -76.034633   \n",
-       "19          Maple Ski Ridge  42.815589 -74.031286   \n",
-       "20        McCauley Mountain  43.395902 -74.889602   \n",
-       "21             Mount Pisgah  44.340885 -74.127932   \n",
-       "22               Plattekill  41.618364 -74.063097   \n",
-       "23  Royal Mountain Ski Area  43.083509 -74.506211   \n",
-       "24             Swain Resort  42.476051 -77.855432   \n",
-       "25   Thunder Ridge Ski Area  41.508554 -73.585486   \n",
-       "26           Titus Mountain  44.754265 -74.241311   \n",
-       "27         Willard Mountain  43.019722 -73.522242   \n",
-       "28    Woods Valley Ski Area  43.302038 -75.382495   \n",
+       "                                  name  \\\n",
+       "0                   Whiteface Mountain   \n",
+       "1                        Gore Mountain   \n",
+       "2                      Hunter Mountain   \n",
+       "3                   Belleayre Mountain   \n",
+       "4                       Holiday Valley   \n",
+       "5                     Windham Mountain   \n",
+       "6                           Greek Peak   \n",
+       "7                   Catamount Ski Area   \n",
+       "8                   Peek'n Peak Resort   \n",
+       "9                             HoliMont   \n",
+       "10                   Beartown Ski Area   \n",
+       "11  Brantling Ski and Snowboard Center   \n",
+       "12                    Bristol Mountain   \n",
+       "13                    Buffalo Ski Club   \n",
+       "14                  Cazenovia Ski Club   \n",
+       "15                  Cockaigne Ski Area   \n",
+       "16                   Dry Hill Ski Area   \n",
+       "17    Four Seasons Golf and Ski Center   \n",
+       "18                  Hickory Ski Center   \n",
+       "19                    Holiday Mountain   \n",
+       "20                Hunt Hollow Ski Club   \n",
+       "21                      Kissing Bridge   \n",
+       "22                   Labrador Mountain   \n",
+       "23                     Maple Ski Ridge   \n",
+       "24                   McCauley Mountain   \n",
+       "25                        Mount Pisgah   \n",
+       "26                  Mt. Peter Ski Area   \n",
+       "27             Oak Mountain Ski Center   \n",
+       "28                          Plattekill   \n",
+       "29                 Polar Peak Ski Bowl   \n",
+       "30             Royal Mountain Ski Area   \n",
+       "31                Ski Big Tupper Again   \n",
+       "32                         Ski Venture   \n",
+       "33                 Snow Ridge Ski Area   \n",
+       "34                       Song Mountain   \n",
+       "35                        Swain Resort   \n",
+       "36              Thunder Ridge Ski Area   \n",
+       "37                      Titus Mountain   \n",
+       "38            West Mountain Ski Center   \n",
+       "39                    Willard Mountain   \n",
+       "40               Woods Valley Ski Area   \n",
+       "\n",
+       "                                                  url vertical_rise  \\\n",
+       "0           https://www.skicentral.com/whiteface.html       3430 ft   \n",
+       "1        https://www.skicentral.com/goremountain.html       2537 ft   \n",
+       "2      https://www.skicentral.com/huntermountain.html       1600 ft   \n",
+       "3           https://www.skicentral.com/belleayre.html       1404 ft   \n",
+       "4       https://www.skicentral.com/holidayvalley.html        750 ft   \n",
+       "5          https://www.skicentral.com/skiwindham.html       1600 ft   \n",
+       "6           https://www.skicentral.com/greekpeak.html        952 ft   \n",
+       "7           https://www.skicentral.com/catamount.html       1000 ft   \n",
+       "8           https://www.skicentral.com/peeknpeak.html        400 ft   \n",
+       "9            https://www.skicentral.com/holimont.html        700 ft   \n",
+       "10    https://www.skicentral.com/beartownskiarea.html        150 ft   \n",
+       "11  https://www.skicentral.com/brantlingskiandsnow...        240 ft   \n",
+       "12    https://www.skicentral.com/bristolmountain.html       1200 ft   \n",
+       "13     https://www.skicentral.com/buffaloskiclub.html        500 ft   \n",
+       "14   https://www.skicentral.com/cazenoviaskiclub.html        460 ft   \n",
+       "15   https://www.skicentral.com/cockaigneskiarea.html        430 ft   \n",
+       "16            https://www.skicentral.com/dryhill.html        300 ft   \n",
+       "17  https://www.skicentral.com/fourseasonsgolfands...         59 ft   \n",
+       "18   https://www.skicentral.com/hickoryskicenter.html       1200 ft   \n",
+       "19    https://www.skicentral.com/holidaymountain.html        400 ft   \n",
+       "20  https://www.skicentral.com/hunthollowskiclub.html        825 ft   \n",
+       "21      https://www.skicentral.com/kissingbridge.html        550 ft   \n",
+       "22   https://www.skicentral.com/labradormountain.html        700 ft   \n",
+       "23      https://www.skicentral.com/mapleskiridge.html       1200 ft   \n",
+       "24   https://www.skicentral.com/mccauleymountain.html        633 ft   \n",
+       "25        https://www.skicentral.com/mountpisgah.html        329 ft   \n",
+       "26     https://www.skicentral.com/mtpeterskiarea.html        400 ft   \n",
+       "27  https://www.skicentral.com/oakmountainskicente...        650 ft   \n",
+       "28         https://www.skicentral.com/plattekill.html       1100 ft   \n",
+       "29   https://www.skicentral.com/polarpeakskibowl.html        114 ft   \n",
+       "30  https://www.skicentral.com/royalmountainskiare...        550 ft   \n",
+       "31          https://www.skicentral.com/bigtupper.html       1151 ft   \n",
+       "32         https://www.skicentral.com/skiventure.html        100 ft   \n",
+       "33   https://www.skicentral.com/snowridgeskiarea.html        500 ft   \n",
+       "34       https://www.skicentral.com/songmountain.html        700 ft   \n",
+       "35     https://www.skicentral.com/swainskicenter.html        650 ft   \n",
+       "36  https://www.skicentral.com/thunderridgeskiarea...        600 ft   \n",
+       "37              https://www.skicentral.com/titus.html       1200 ft   \n",
+       "38  https://www.skicentral.com/westmountainskicent...        460 ft   \n",
+       "39  https://www.skicentral.com/willardmountainnewy...        505 ft   \n",
+       "40  https://www.skicentral.com/woodsvalleyskiarea....        500 ft   \n",
+       "\n",
+       "   base_elevation summit_elevation annual_snowfall number_of_trails  \\\n",
+       "0         1220 ft          4650 ft      190 inches               90   \n",
+       "1          998 ft          3600 ft      150 inches              107   \n",
+       "2         1600 ft          3200 ft      125 inches               58   \n",
+       "3         2025 ft          3429 ft      141 inches               50   \n",
+       "4         1500 ft          2250 ft      180 inches               58   \n",
+       "5         1500 ft          3100 ft      105 inches               54   \n",
+       "6         1148 ft          2100 ft      122 inches               38   \n",
+       "7         1000 ft          2000 ft       75 inches               36   \n",
+       "8         1400 ft          1800 ft      200 inches               27   \n",
+       "9         1560 ft          2260 ft      180 inches               52   \n",
+       "10            n/a              n/a             n/a                9   \n",
+       "11            n/a              n/a             n/a                9   \n",
+       "12        1000 ft          2200 ft             n/a               35   \n",
+       "13        2025 ft          3429 ft             n/a               43   \n",
+       "14            n/a              n/a             n/a               13   \n",
+       "15        1592 ft          2022 ft      175 inches               15   \n",
+       "16         650 ft           950 ft      125 inches                7   \n",
+       "17         545 ft           604 ft             n/a                4   \n",
+       "18         700 ft          1900 ft       80 inches               18   \n",
+       "19        1150 ft          1500 ft       90 inches                6   \n",
+       "20            n/a              n/a             n/a               20   \n",
+       "21        1200 ft          1750 ft      182 inches               38   \n",
+       "22        1125 ft          1825 ft      125 inches               22   \n",
+       "23         750 ft           450 ft             n/a                8   \n",
+       "24        1567 ft          2200 ft      281 inches               21   \n",
+       "25            n/a              n/a             n/a                5   \n",
+       "26            n/a              n/a       49 inches               14   \n",
+       "27        1750 ft          2400 ft      120 inches               22   \n",
+       "28        2400 ft          3500 ft      190 inches               35   \n",
+       "29            n/a           660 ft       65 inches               10   \n",
+       "30            n/a              n/a             n/a               14   \n",
+       "31        2000 ft          3136 ft       90 inches               25   \n",
+       "32            n/a              n/a             n/a               12   \n",
+       "33            n/a          2000 ft      230 inches               22   \n",
+       "34            n/a              n/a             n/a               24   \n",
+       "35        1320 ft          1970 ft      130 inches               30   \n",
+       "36            n/a           820 ft       33 inches               30   \n",
+       "37         825 ft          2025 ft      130 inches               36   \n",
+       "38        1010 ft          1470 ft             n/a               40   \n",
+       "39         910 ft          1415 ft             n/a               14   \n",
+       "40            n/a              n/a             n/a               15   \n",
+       "\n",
+       "   skiable_acres         longest_run snowmaking   latitude  longitude  \\\n",
+       "0            288  2.1 miles / 3.4 km        98%  44.365784 -73.902984   \n",
+       "1            439  4.4 miles / 7.1 km        97%  43.672954 -74.048853   \n",
+       "2            240                 n/a       100%  42.177866 -74.230422   \n",
+       "3            171                 n/a        96%  42.126893 -74.474075   \n",
+       "4            290  0.8 miles / 1.3 km        95%  42.263145 -78.663611   \n",
+       "5            285                 n/a        97%  42.293926 -74.261312   \n",
+       "6            220  1.5 miles / 2.4 km        83%  42.502320 -76.148046   \n",
+       "7            130  1.8 miles / 2.8 km        98%        NaN        NaN   \n",
+       "8            105      0 miles / 1 km       100%  42.060463 -79.744066   \n",
+       "9            135                 n/a       100%  42.270015 -78.683382   \n",
+       "10           n/a                 n/a        yes  44.764111 -73.584055   \n",
+       "11            35                 n/a        60%        NaN        NaN   \n",
+       "12           138                 n/a        97%  42.744830 -77.403694   \n",
+       "13           300                 n/a        yes  42.677615 -78.697081   \n",
+       "14            25                 n/a         no  42.977599 -75.852806   \n",
+       "15           100                 n/a         no        NaN        NaN   \n",
+       "16            35                 n/a        yes  43.930346 -75.901776   \n",
+       "17            12                 n/a        50%        NaN        NaN   \n",
+       "18           225                 n/a         no  43.474359 -73.816768   \n",
+       "19            37                 n/a       100%  41.628043 -74.606688   \n",
+       "20            80                 n/a        yes  42.644112 -77.481358   \n",
+       "21           700                 n/a        90%  42.599704 -78.657497   \n",
+       "22           250    1 miles / 1.6 km        90%  42.740240 -76.034633   \n",
+       "23            25                 n/a        95%  42.815589 -74.031286   \n",
+       "24            75                 n/a        65%  43.395902 -74.889602   \n",
+       "25            15                 n/a       100%  44.340885 -74.127932   \n",
+       "26            69                 n/a       100%        NaN        NaN   \n",
+       "27           n/a  1.5 miles / 2.4 km        30%        NaN        NaN   \n",
+       "28           112    2 miles / 3.2 km        75%  41.618364 -74.063097   \n",
+       "29           n/a  0.3 miles / 0.4 km        90%        NaN        NaN   \n",
+       "30            30                 n/a        95%  43.083509 -74.506211   \n",
+       "31           n/a                 n/a         no        NaN        NaN   \n",
+       "32           n/a                 n/a         no        NaN        NaN   \n",
+       "33           130                 n/a        50%        NaN        NaN   \n",
+       "34           100                 n/a        80%        NaN        NaN   \n",
+       "35           100    1 miles / 1.6 km        97%  42.476051 -77.855432   \n",
+       "36            90                 n/a       100%  41.508554 -73.585486   \n",
+       "37           200                 n/a        90%  44.754265 -74.241311   \n",
+       "38           124                 n/a        70%        NaN        NaN   \n",
+       "39            50                 n/a        yes  43.019722 -73.522242   \n",
+       "40            25                 n/a        yes  43.302038 -75.382495   \n",
        "\n",
        "                                              address  \n",
        "0   Whiteface Mountain, Essex County, New York, Un...  \n",
@@ -326,31 +989,43 @@
        "4   Holiday Valley, Town of Ellicottville, Cattara...  \n",
        "5   Windham Mountain Club, Town of Windham, Greene...  \n",
        "6   Greek Peak Mountain Resort, 2000, South Hill R...  \n",
-       "7   Peek'n Peak Resort, Abbey Lane, Town of French...  \n",
-       "8   Holimont, Village of Ellicottville, Town of El...  \n",
-       "9   Beartown Ski Area, Beartown Road, Beartown, To...  \n",
-       "10  Bristol Mountain, North Star Village, Town of ...  \n",
-       "11  Buffalo Ski Club, Town of Boston, Erie County,...  \n",
-       "12  Cazenovia Ski Club, Rathbun Road, Town of Caze...  \n",
-       "13  Dry Hill Ski Area, Town of Watertown, Jefferso...  \n",
-       "14  Hickory Ski Center, Hickory Hill Road, Town of...  \n",
-       "15  Holiday Mountain Trail, Bridgeville, Rock Hill...  \n",
-       "16  Hunt Hollow Ski Club, Hunt Hollow, Town of Nap...  \n",
-       "17  Kissing Bridge, Footes, Town of Concord, Erie ...  \n",
-       "18  Labrador Mountain, 6935, Town of Truxton, Cort...  \n",
-       "19  Maple Ski Ridge, Mariaville Road, Town of Rott...  \n",
-       "20  McCauley Mountain, Herkimer County, New York, ...  \n",
-       "21  Mount Pisgah, Town of Saint Armand, Essex Coun...  \n",
-       "22  Plattekill, Ulster County, New York, 12568, Un...  \n",
-       "23  Royal Mountain Ski Area, North Bush, Town of C...  \n",
-       "24  Swain Resort, County Road 24, Swain, Town of G...  \n",
-       "25  Thunder Ridge Ski Area, Thunder Ridge Road, To...  \n",
-       "26  Titus Mountain ski resort, Town of Malone, Fra...  \n",
-       "27  Willard Mountain, Washington County, New York,...  \n",
-       "28  Woods Valley Ski Area, 9100, State Highway 46,...  "
+       "7                                                 NaN  \n",
+       "8   Peek'n Peak Resort, Abbey Lane, Town of French...  \n",
+       "9   Holimont, Village of Ellicottville, Town of El...  \n",
+       "10  Beartown Ski Area, Beartown Road, Beartown, To...  \n",
+       "11                                                NaN  \n",
+       "12  Bristol Mountain, North Star Village, Town of ...  \n",
+       "13  Buffalo Ski Club, Town of Boston, Erie County,...  \n",
+       "14  Cazenovia Ski Club, Rathbun Road, Town of Caze...  \n",
+       "15                                                NaN  \n",
+       "16  Dry Hill Ski Area, Town of Watertown, Jefferso...  \n",
+       "17                                                NaN  \n",
+       "18  Hickory Ski Center, Hickory Hill Road, Town of...  \n",
+       "19  Holiday Mountain Trail, Bridgeville, Rock Hill...  \n",
+       "20  Hunt Hollow Ski Club, Hunt Hollow, Town of Nap...  \n",
+       "21  Kissing Bridge, Footes, Town of Concord, Erie ...  \n",
+       "22  Labrador Mountain, 6935, Town of Truxton, Cort...  \n",
+       "23  Maple Ski Ridge, Mariaville Road, Town of Rott...  \n",
+       "24  McCauley Mountain, Herkimer County, New York, ...  \n",
+       "25  Mount Pisgah, Town of Saint Armand, Essex Coun...  \n",
+       "26                                                NaN  \n",
+       "27                                                NaN  \n",
+       "28  Plattekill, Ulster County, New York, 12568, Un...  \n",
+       "29                                                NaN  \n",
+       "30  Royal Mountain Ski Area, North Bush, Town of C...  \n",
+       "31                                                NaN  \n",
+       "32                                                NaN  \n",
+       "33                                                NaN  \n",
+       "34                                                NaN  \n",
+       "35  Swain Resort, County Road 24, Swain, Town of G...  \n",
+       "36  Thunder Ridge Ski Area, Thunder Ridge Road, To...  \n",
+       "37  Titus Mountain ski resort, Town of Malone, Fra...  \n",
+       "38                                                NaN  \n",
+       "39  Willard Mountain, Washington County, New York,...  \n",
+       "40  Woods Valley Ski Area, 9100, State Highway 46,...  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -358,954 +1033,29 @@
    "source": [
     "geolocator = Nominatim(user_agent=\"DCJT3_NY_SKI\")\n",
     "\n",
-    "resorts_data = []\n",
-    "\n",
-    "for name in resort_names:\n",
-    "    location = geolocator.geocode(f\"{name}, NY\")\n",
+    "for resort in resorts:\n",
+    "    location = geolocator.geocode(f\"{resort['name']}, NY\")\n",
     "    if location:\n",
-    "        resorts_data.append({'name': name,\n",
-    "                             'latitude': location.latitude,\n",
-    "                             'longitude': location.longitude,\n",
-    "                             'address': location.address})\n",
+    "        resort['latitude'] = location.latitude\n",
+    "        resort['longitude'] = location.longitude\n",
+    "        resort['address'] = location.address\n",
+    "\n",
+    "    # Mountain stats scrape\n",
+    "    response = requests.get(resort['url'])\n",
+    "    resort_soup = BeautifulSoup(response.text, 'html.parser')\n",
+    "    stats_table = resort_soup.find('table', id='mountainstatistics')\n",
+    "\n",
+    "    if stats_table:\n",
+    "        for row in stats_table.find_all('tr'):\n",
+    "            cols = row.find_all(['td', 'th'])\n",
+    "            if len(cols) == 2:\n",
+    "                stat_name = cols[0].text.strip().lower().replace(' ', '_')\n",
+    "                stat_value = cols[1].text.strip()\n",
+    "                resort[stat_name] = stat_value\n",
     "    time.sleep(1)\n",
     "\n",
-    "df = pd.DataFrame(resorts_data)\n",
+    "df = pd.DataFrame(resorts)\n",
     "df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.plotly.v1+json": {
-       "config": {
-        "plotlyServerURL": "https://plot.ly"
-       },
-       "data": [
-        {
-         "hovertemplate": "<b>%{hovertext}</b><br><br>latitude=%{lat}<br>longitude=%{lon}<extra></extra>",
-         "hovertext": [
-          "Whiteface Mountain",
-          "Gore Mountain",
-          "Hunter Mountain",
-          "Belleayre Mountain",
-          "Holiday Valley",
-          "Windham Mountain",
-          "Greek Peak",
-          "Peek'n Peak Resort",
-          "HoliMont"
-         ],
-         "lat": [
-          44.3657845,
-          43.672954,
-          42.1778662,
-          42.12689335,
-          42.2631454,
-          42.29392565,
-          42.50232045,
-          42.06046265,
-          42.270014700000004
-         ],
-         "legendgroup": "",
-         "lon": [
-          -73.9029843,
-          -74.0488526,
-          -74.2304216,
-          -74.47407468091113,
-          -78.6636114,
-          -74.2613118092174,
-          -76.14804555790452,
-          -79.7440664815112,
-          -78.68338240179332
-         ],
-         "marker": {
-          "color": "#636efa"
-         },
-         "mode": "markers",
-         "name": "",
-         "showlegend": false,
-         "subplot": "mapbox",
-         "type": "scattermapbox"
-        }
-       ],
-       "layout": {
-        "legend": {
-         "tracegroupgap": 0
-        },
-        "mapbox": {
-         "center": {
-          "lat": 43.2994,
-          "lon": -74.2179
-         },
-         "domain": {
-          "x": [
-           0,
-           1
-          ],
-          "y": [
-           0,
-           1
-          ]
-         },
-         "style": "carto-positron",
-         "zoom": 5
-        },
-        "margin": {
-         "t": 60
-        },
-        "template": {
-         "data": {
-          "bar": [
-           {
-            "error_x": {
-             "color": "#2a3f5f"
-            },
-            "error_y": {
-             "color": "#2a3f5f"
-            },
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "bar"
-           }
-          ],
-          "barpolar": [
-           {
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "barpolar"
-           }
-          ],
-          "carpet": [
-           {
-            "aaxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "baxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "type": "carpet"
-           }
-          ],
-          "choropleth": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "choropleth"
-           }
-          ],
-          "contour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "contour"
-           }
-          ],
-          "contourcarpet": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "contourcarpet"
-           }
-          ],
-          "heatmap": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "heatmap"
-           }
-          ],
-          "heatmapgl": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "heatmapgl"
-           }
-          ],
-          "histogram": [
-           {
-            "marker": {
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "histogram"
-           }
-          ],
-          "histogram2d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2d"
-           }
-          ],
-          "histogram2dcontour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2dcontour"
-           }
-          ],
-          "mesh3d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "mesh3d"
-           }
-          ],
-          "parcoords": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "parcoords"
-           }
-          ],
-          "pie": [
-           {
-            "automargin": true,
-            "type": "pie"
-           }
-          ],
-          "scatter": [
-           {
-            "fillpattern": {
-             "fillmode": "overlay",
-             "size": 10,
-             "solidity": 0.2
-            },
-            "type": "scatter"
-           }
-          ],
-          "scatter3d": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatter3d"
-           }
-          ],
-          "scattercarpet": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattercarpet"
-           }
-          ],
-          "scattergeo": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergeo"
-           }
-          ],
-          "scattergl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergl"
-           }
-          ],
-          "scattermapbox": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattermapbox"
-           }
-          ],
-          "scatterpolar": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolar"
-           }
-          ],
-          "scatterpolargl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolargl"
-           }
-          ],
-          "scatterternary": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterternary"
-           }
-          ],
-          "surface": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "surface"
-           }
-          ],
-          "table": [
-           {
-            "cells": {
-             "fill": {
-              "color": "#EBF0F8"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "header": {
-             "fill": {
-              "color": "#C8D4E3"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "type": "table"
-           }
-          ]
-         },
-         "layout": {
-          "annotationdefaults": {
-           "arrowcolor": "#2a3f5f",
-           "arrowhead": 0,
-           "arrowwidth": 1
-          },
-          "autotypenumbers": "strict",
-          "coloraxis": {
-           "colorbar": {
-            "outlinewidth": 0,
-            "ticks": ""
-           }
-          },
-          "colorscale": {
-           "diverging": [
-            [
-             0,
-             "#8e0152"
-            ],
-            [
-             0.1,
-             "#c51b7d"
-            ],
-            [
-             0.2,
-             "#de77ae"
-            ],
-            [
-             0.3,
-             "#f1b6da"
-            ],
-            [
-             0.4,
-             "#fde0ef"
-            ],
-            [
-             0.5,
-             "#f7f7f7"
-            ],
-            [
-             0.6,
-             "#e6f5d0"
-            ],
-            [
-             0.7,
-             "#b8e186"
-            ],
-            [
-             0.8,
-             "#7fbc41"
-            ],
-            [
-             0.9,
-             "#4d9221"
-            ],
-            [
-             1,
-             "#276419"
-            ]
-           ],
-           "sequential": [
-            [
-             0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1,
-             "#f0f921"
-            ]
-           ],
-           "sequentialminus": [
-            [
-             0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1,
-             "#f0f921"
-            ]
-           ]
-          },
-          "colorway": [
-           "#636efa",
-           "#EF553B",
-           "#00cc96",
-           "#ab63fa",
-           "#FFA15A",
-           "#19d3f3",
-           "#FF6692",
-           "#B6E880",
-           "#FF97FF",
-           "#FECB52"
-          ],
-          "font": {
-           "color": "#2a3f5f"
-          },
-          "geo": {
-           "bgcolor": "white",
-           "lakecolor": "white",
-           "landcolor": "#E5ECF6",
-           "showlakes": true,
-           "showland": true,
-           "subunitcolor": "white"
-          },
-          "hoverlabel": {
-           "align": "left"
-          },
-          "hovermode": "closest",
-          "mapbox": {
-           "style": "light"
-          },
-          "paper_bgcolor": "white",
-          "plot_bgcolor": "#E5ECF6",
-          "polar": {
-           "angularaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "radialaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           }
-          },
-          "scene": {
-           "xaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "yaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "zaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           }
-          },
-          "shapedefaults": {
-           "line": {
-            "color": "#2a3f5f"
-           }
-          },
-          "ternary": {
-           "aaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "baxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "caxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           }
-          },
-          "title": {
-           "x": 0.05
-          },
-          "xaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
-           },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
-          },
-          "yaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
-           },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
-          }
-         }
-        },
-        "title": {
-         "text": "New York Ski Resorts"
-        }
-       }
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "fig = px.scatter_mapbox(df[:9], \n",
-    "                       lat='latitude', \n",
-    "                       lon='longitude',\n",
-    "                       hover_name='name',\n",
-    "                       zoom=5,\n",
-    "                       mapbox_style='carto-positron')\n",
-    "\n",
-    "# Update the layout to center on NY\n",
-    "fig.update_layout(\n",
-    "    title='New York Ski Resorts',\n",
-    "    mapbox=dict(\n",
-    "        center=dict(lat=43.2994, lon=-74.2179)  # Center of NY State\n",
-    "    )\n",
-    ")\n",
-    "\n",
-    "fig.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Holiday Valley and HoliMont are in the same city, so defining which resorts/areas will have to be done."
    ]
   },
   {
@@ -1317,7 +1067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -1332,9 +1082,9 @@
       "3   Belleayre Mountain  42.126893 -74.474075\n",
       "5     Windham Mountain  42.293926 -74.261312\n",
       "6           Greek Peak  42.502320 -76.148046\n",
-      "7   Peek'n Peak Resort  42.060463 -79.744066\n",
-      "8             HoliMont  42.270015 -78.683382\n",
-      "15    Holiday Mountain  41.628043 -74.606688\n"
+      "8   Peek'n Peak Resort  42.060463 -79.744066\n",
+      "9             HoliMont  42.270015 -78.683382\n",
+      "19    Holiday Mountain  41.628043 -74.606688\n"
      ]
     }
    ],
@@ -2284,13 +2034,6 @@
     "\n",
     "fig.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Updated the data so that the mountain statistics are included. I was able to parse the individual links to the pages for each of these resorts where their respective statistics are held. Let's use this to create the top nine resorts depending on a certain statistic like `vertical_rise` or `summit_elevation`.